### PR TITLE
Changed Asterisk AMI URI according to wiki, adjusted stringcheck

### DIFF
--- a/asterisk.js
+++ b/asterisk.js
@@ -107,14 +107,13 @@ browser.browserAction.onClicked.addListener((handleClick) => {
 function placingCall(selectedNumber) {
   let xhr_login = new XMLHttpRequest();
   let xhr = new XMLHttpRequest();
-  xhr_login.open("GET", "http://" + asteriskServer + ":" + asteriskPort + "/rawman?action=Login&Username=" + asteriskUsername + "&Secret=" + asteriskPassword);
+  xhr_login.open("GET", "http://" + asteriskServer + ":" + asteriskPort + "/mxml?action=Login&Username=" + asteriskUsername + "&Secret=" + asteriskPassword);
   xhr_login.send("");
   xhr_login.onreadystatechange = function() {
       if (xhr_login.readyState == 4 && (xhr_login.status == 200 || xhr_login.status == 0)) {
           console.log(xhr_login.responseText);
-          var response = xhr_login.responseText;
-          console.log(xhr_login.responseText);
-	  var success = xhr_login.responseText.split("\r\n")[0].split(": ")[1];
+          var response = xhr_login.responseXML;
+          var success = response.getElementsByTagName("generic")[0].getAttribute('response')
           //console.log(success);
           if (success == "Success") {
             xhr.open("GET", "http://" + asteriskServer + ":" + asteriskPort + "/mxml?action=originate&channel=" + asteriskProtocol + "/" + asteriskChannel + "&exten=" + selectedNumber + "&context=" + asteriskContext + "&CallerId=" + asteriskChannel + "&priority=1&codecs=alaw&timeout=5000");

--- a/asterisk.js
+++ b/asterisk.js
@@ -107,16 +107,17 @@ browser.browserAction.onClicked.addListener((handleClick) => {
 function placingCall(selectedNumber) {
   let xhr_login = new XMLHttpRequest();
   let xhr = new XMLHttpRequest();
-  xhr_login.open("GET", "http://" + asteriskServer + ":" + asteriskPort + "/asterisk/mxml?action=Login&Username=" + asteriskUsername + "&Secret=" + asteriskPassword);
+  xhr_login.open("GET", "http://" + asteriskServer + ":" + asteriskPort + "/rawman?action=Login&Username=" + asteriskUsername + "&Secret=" + asteriskPassword);
   xhr_login.send("");
   xhr_login.onreadystatechange = function() {
       if (xhr_login.readyState == 4 && (xhr_login.status == 200 || xhr_login.status == 0)) {
           console.log(xhr_login.responseText);
-          var response = xhr_login.responseXML;
-          var success = response.getElementsByTagName("generic")[0].getAttribute('response')
+          var response = xhr_login.responseText;
+          console.log(xhr_login.responseText);
+	  var success = xhr_login.responseText.split("\r\n")[0].split(": ")[1];
           //console.log(success);
           if (success == "Success") {
-            xhr.open("GET", "http://" + asteriskServer + ":" + asteriskPort + "/asterisk/mxml?action=originate&channel=" + asteriskProtocol + "/" + asteriskChannel + "&exten=" + selectedNumber + "&context=" + asteriskContext + "&CallerId=" + asteriskChannel + "&priority=1&codecs=alaw&timeout=5000");
+            xhr.open("GET", "http://" + asteriskServer + ":" + asteriskPort + "/mxml?action=originate&channel=" + asteriskProtocol + "/" + asteriskChannel + "&exten=" + selectedNumber + "&context=" + asteriskContext + "&CallerId=" + asteriskChannel + "&priority=1&codecs=alaw&timeout=5000");
             xhr.send("");
           }
           else {


### PR DESCRIPTION
Hi, while attempting to use this plugin with my local Asterisk 18 installation I noticed two bits:
1. URIs to Asterisk Manager Interface seem to have changed, omitting /asterist/
Interestingly enough, calling the mxml endpoint to login succeeds but I could not authenticate afterwards to originate the call.
2. The stringcheck on success has not been able to complete as XMLHttüRequest.responseXML returns None
Probably bc the rawman endpoint never was intended to return XML?

I may have a few mixups regarding the different endpoint which led to unnecessary changes, if you have any I would appreciate extended documentation for these, I found the ami articles on wiki.asterisk.com rather lacking.